### PR TITLE
Update indeterminatebeam.py

### DIFF
--- a/indeterminatebeam/indeterminatebeam.py
+++ b/indeterminatebeam/indeterminatebeam.py
@@ -1889,7 +1889,7 @@ class Beam:
     def __str__(self):
         return f"""--------------------------------
         <Beam>
-        length = {self._x0}
+        length = {self._x1 - self._x0}
         loads = {str(len(self._loads))}"""
 
     def __repr__(self):


### PR DESCRIPTION
Currently when the beam object is printed, the length always reports as "0". This change should make it print the correct length.